### PR TITLE
Avoid pulling in System.Net.Http in netstandard projects.

### DIFF
--- a/SimpleIdentityServer/src/Apis/Scim/SimpleIdentityServer.Scim.Common/SimpleIdentityServer.Scim.Common.csproj
+++ b/SimpleIdentityServer/src/Apis/Scim/SimpleIdentityServer.Scim.Common/SimpleIdentityServer.Scim.Common.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>SimpleIdentityServer.Scim.Common Class Library</Description>
@@ -21,7 +21,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Pulling in System.Net.Http in netstandard compilation gives warnings for consumers of the library.